### PR TITLE
バックエンド corsの設定を追加、docker-composeビルド遅い問題修正

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 utoipa = { version = "4.2.3", features = ["actix_extras"] }
 utoipa-swagger-ui = { version = "7.1.0", features = ["actix-web"] }
 serde_json = "1.0.117"
+actix-cors = "0.7.0"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,7 +2,8 @@ mod controller;
 mod form;
 mod model;
 mod setting;
-use actix_web::{web, App, HttpServer};
+use actix_cors::Cors;
+use actix_web::{http, web, App, HttpServer};
 use dotenv::dotenv;
 use std::env;
 use utoipa::OpenApi;
@@ -26,7 +27,13 @@ async fn main() -> std::io::Result<()> {
     let state: setting::AppState = setting::AppState { conn };
 
     HttpServer::new(move || {
+        let cors = Cors::default()
+            .allowed_origin("http://localhost:3000")
+            .allowed_methods(vec!["GET", "POST", "OPTIONS", "DELETE", "PUT"])
+            .allowed_header(http::header::CONTENT_TYPE);
+
         App::new()
+            .wrap(cors)
             .app_data(web::Data::new(state.clone()))
             .service(controller::health_check::health_check)
             .service(controller::movie_manage::movie_register)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     command: "cargo watch -x run --poll"
     volumes:
       - ./backend:/projects
+      - backend_target:/projects/target
     working_dir: /projects
     ports:
       - "8080:8080"
@@ -44,3 +45,6 @@ services:
 networks:
   app-net:
     driver: bridge
+
+volumes:
+  backend_target:


### PR DESCRIPTION
# このPRで達成したいこと
- ブラウザからのリクエストでCORSエラーが発生しないようにしたい

# このPRの内容を簡潔に
- CORSの設定を追加
- 許可するヘッダーを追加
- (バックエンド開発体験向上) ビルドした成果物を名前付きボリューム内に配置するように修正

# このPRにおける注意点(もしあれば)
このPRにおける注意点ではないですが、登録APIのリクエストパラメータにあるsession_tokenはまだログイン機能が完成してないので適当な文字列を入れておいてください