### PR TITLE
vscode上でprettierを適用させる

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-	"rust-analyzer.showUnlinkedFileNotification": false
+  "rust-analyzer.showUnlinkedFileNotification": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  }
 }


### PR DESCRIPTION
# このPRで達成したいこと
- 以前，prettierが反応しなかった
- vimのキーバウンド設定が原因だと思ったが，`ctrl+s`でも反応しないことがあった
- vscodeの`settings.json`に追記することで解決

# このPRの内容を簡潔に
- `settings.json`にデフォルトのフォーマッターにする内容を追記
- 保存時にフォーマットするように追記

# このPRにおける注意点(もしあれば)

