### PR TITLE
tsconfig.jsonを読み込めない状態の修正

### DIFF
--- a/frontend/projects/eslint.config.js
+++ b/frontend/projects/eslint.config.js
@@ -52,7 +52,7 @@ export default defineConfig([
       parserOptions: {
         project: "./tsconfig.json",
         tsconfigRootDir:
-          "/Users/hokto/Desktop/movie_management-develop/frontend/projects",
+          import.meta.dirname,
       },
     },
 


### PR DESCRIPTION
# このPRで達成したいこと
- 私以外の環境でもeslintが正しく動作するようにした

# このPRの内容を簡潔に
- `ts.config`の参照場所を絶対パスで入れていた…
- `eslint.config.js`からの相対パスで参照することで解決

# このPRにおける注意点(もしあれば)
#39 もこれで直るか試してほしい
